### PR TITLE
Setup.py file contains odd commas

### DIFF
--- a/doc/source/user/getting_started.rst
+++ b/doc/source/user/getting_started.rst
@@ -28,6 +28,8 @@ Ubuntu
    $ sudo easy_install numdifftools
    $ sudo easy_install scikits.scattpy
 
+Note: $ sudo apt-get install python-scipy doesn't work on Ubuntu 10.04. Please use, Ubuntu 10.10 or higher.
+
 Windows
 -------
 

--- a/setup.py
+++ b/setup.py
@@ -15,8 +15,8 @@ import sys
 DISTNAME            = 'scikits.scattpy'
 DESCRIPTION         = 'Light Scattering methods for Python'
 LONG_DESCRIPTION    = descr
-MAINTAINER          = 'Alexander Vinokurov',
-MAINTAINER_EMAIL    = 'scattpy@googlegroups.com',
+MAINTAINER          = 'Alexander Vinokurov'
+MAINTAINER_EMAIL    = 'scattpy@googlegroups.com'
 URL                 = 'http://scattpy.github.com'
 LICENSE             = 'BSD'
 VERSION             = '0.1.2'

--- a/src/f_utils.for
+++ b/src/f_utils.for
@@ -148,8 +148,8 @@ cf2py intent(hide) NG,NN
       SUBROUTINE f1(NG,R,Rd,Rdd,Sint,Cost,f)
       implicit real*8 (r)
       INTEGER NG
-      REAL*8 R(NG),Rd(NG),Sint(NG),Cost(NG),f(NG)
-cf2py intent(in) R,Rd,Sint,Cost
+      REAL*8 R(NG),Rdd(NG),Rd(NG),Sint(NG),Cost(NG),f(NG)
+cf2py intent(in) R,Rd,Rdd,Sint,Cost
 cf2py intent(out) f
 cf2py intent(hide) NG
       INTEGER K
@@ -180,8 +180,8 @@ cf2py intent(hide) NG
       SUBROUTINE f2(NG,R,Rd,Rdd,f)
       implicit real*8 (r)
       INTEGER NG
-      REAL*8 R(NG),Rd(NG),Sint(NG),Cost(NG),f(NG)
-cf2py intent(in) R,Rd,Sint,Cost
+      REAL*8 R(NG),Rdd(NG),Rd(NG),Sint(NG),Cost(NG),f(NG)
+cf2py intent(in) R,Rd,Rdd,Sint,Cost
 cf2py intent(out) f
 cf2py intent(hide) NG
       INTEGER K
@@ -204,8 +204,8 @@ cf2py intent(hide) NG
       SUBROUTINE f3(NG,R,Rd,Rdd,Sint,Cost,f)
       implicit real*8 (r)
       INTEGER NG
-      REAL*8 R(NG),Rd(NG),Sint(NG),Cost(NG),f(NG)
-cf2py intent(in) R,Rd,Sint,Cost
+      REAL*8 R(NG),Rd(NG),Rdd(NG),Sint(NG),Cost(NG),f(NG)
+cf2py intent(in) R,Rd,Rdd,Sint,Cost
 cf2py intent(out) f
 cf2py intent(hide) NG
       INTEGER K
@@ -236,8 +236,8 @@ cf2py intent(hide) NG
       SUBROUTINE f4(NG,R,Rd,Rdd,Sint,Cost,f)
       implicit real*8 (r)
       INTEGER NG
-      REAL*8 R(NG),Rd(NG),Sint(NG),Cost(NG),f(NG)
-cf2py intent(in) R,Rd,Sint,Cost
+      REAL*8 R(NG),Rd(NG),Rdd(NG),Sint(NG),Cost(NG),f(NG)
+cf2py intent(in) R,Rd,Rdd,Sint,Cost
 cf2py intent(out) f
 cf2py intent(hide) NG
       INTEGER K


### PR DESCRIPTION
Setup.py contains odd commas:
MAINTAINER = 'Alexander Vinokurov'
MAINTAINER_EMAIL = 'scattpy@googlegroups.com'
...
It prevents from installation due to error:
Traceback (most recent call last):
File "setup.py", line 79, in 
'Topic :: Scientific/Engineering :: Astronomy', ])
File "C:\Python27\lib\site-packages\numpy\distutils\core.py", line 186, in set
up
return old_setup(**new_attr)
File "C:\Python27\lib\distutils\core.py", line 152, in setup
dist.run_commands()
File "C:\Python27\lib\distutils\dist.py", line 953, in run_commands
self.run_command(cmd)
File "C:\Python27\lib\distutils\dist.py", line 972, in run_command
cmd_obj.run()
File "C:\Python27\lib\site-packages\distribute-0.6.21-py2.7.egg\setuptools\com
mand\bdist_wininst.py", line 38, in run
_bdist_wininst.run(self)
File "C:\Python27\lib\distutils\command\bdist_wininst.py", line 185, in run
self.create_exe(arcname, fullname, self.bitmap)
File "C:\Python27\lib\site-packages\distribute-0.6.21-py2.7.egg\setuptools\com
mand\bdist_wininst.py", line 7, in create_exe
_bdist_wininst.create_exe(self, arcname, fullname, bitmap)
File "C:\Python27\lib\distutils\command\bdist_wininst.py", line 255, in create
_exe
cfgdata = self.get_inidata()
File "C:\Python27\lib\distutils\command\bdist_wininst.py", line 223, in get_in
idata
(string.capitalize(name), escape(data)))
File "C:\Python27\lib\distutils\command\bdist_wininst.py", line 216, in escape

return string.replace(s, "\n", "\n")
File "C:\Python27\lib\string.py", line 519, in replace
return s.replace(old, new, maxreplace)
AttributeError: 'tuple' object has no attribute 'replace'

Suggested fix:
Remove unnecessary commas.
